### PR TITLE
iOS 6 compatibility

### DIFF
--- a/WMGaugeView/WMGaugeView.m
+++ b/WMGaugeView/WMGaugeView.m
@@ -298,7 +298,13 @@
     UIColor* color = _unitOfMeasurementColor ? _unitOfMeasurementColor : [UIColor whiteColor];
     NSDictionary* stringAttrs = @{ NSFontAttributeName : font, NSForegroundColorAttributeName : color };
     NSAttributedString* attrStr = [[NSAttributedString alloc] initWithString:_unitOfMeasurement attributes:stringAttrs];
-    CGSize fontWidth = [_unitOfMeasurement sizeWithAttributes:stringAttrs];
+    CGSize fontWidth;
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+        fontWidth = [_unitOfMeasurement sizeWithFont:font];
+    } else {
+        fontWidth = [_unitOfMeasurement sizeWithAttributes:stringAttrs];
+    }
+
     [attrStr drawAtPoint:CGPointMake(0.5 - fontWidth.width / 2.0, _unitOfMeasurementVerticalOffset)];
 }
 
@@ -344,7 +350,13 @@
             UIFont* font = _scaleFont ? _scaleFont : [UIFont fontWithName:@"Helvetica-Bold" size:0.05];
             NSDictionary* stringAttrs = @{ NSFontAttributeName : font, NSForegroundColorAttributeName : color };
             NSAttributedString* attrStr = [[NSAttributedString alloc] initWithString:valueString attributes:stringAttrs];
-            CGSize fontWidth = [valueString sizeWithAttributes:stringAttrs];
+            CGSize fontWidth;
+            if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+                fontWidth = [valueString sizeWithFont:font];
+            } else {
+                fontWidth = [valueString sizeWithAttributes:stringAttrs];
+            }
+            
             [attrStr drawAtPoint:CGPointMake(0.5 - fontWidth.width / 2.0, y3 + 0.005)];
         }
         // Subdivision
@@ -597,8 +609,12 @@
     UIFont* font = _rangeLabelsFont ? _rangeLabelsFont : [UIFont fontWithName:@"Helvetica" size:0.05];
     UIColor* color = _rangeLabelsFontColor ? _rangeLabelsFontColor : [UIColor whiteColor];
     NSDictionary* stringAttrs = @{ NSFontAttributeName : font, NSForegroundColorAttributeName : color };
-    CGSize textSize = [text sizeWithAttributes:stringAttrs];
- 
+    CGSize textSize;
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+        textSize = [text sizeWithFont:font];
+    } else {
+        textSize = [text sizeWithAttributes:stringAttrs];
+    }
     float perimeter = 2 * M_PI * radius;
     float textAngle = textSize.width / perimeter * 2 * M_PI * _rangeLabelsFontKerning;
     float offset = ((endAngle - startAngle) - textAngle) / 2.0;
@@ -612,11 +628,23 @@
         NSRange range = {index, 1};
         NSString* letter = [text substringWithRange:range];
         NSAttributedString* attrStr = [[NSAttributedString alloc] initWithString:letter attributes:stringAttrs];
-        CGSize charSize = [letter sizeWithAttributes:stringAttrs];
-  
-        float totalWidth = [[NSString stringWithFormat:@"%@%@", lastLetter, letter] sizeWithAttributes:stringAttrs].width;
-        float currentLetterWidth = [letter sizeWithAttributes:stringAttrs].width;
-        float lastLetterWidth = [lastLetter sizeWithAttributes:stringAttrs].width;
+        CGSize charSize;
+        float totalWidth;
+        float currentLetterWidth;
+        float lastLetterWidth;
+        if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1) {
+            charSize = [letter sizeWithFont:font];
+            totalWidth = [[NSString stringWithFormat:@"%@%@", lastLetter, letter] sizeWithFont:font].width;
+            currentLetterWidth = [letter sizeWithFont:font].width;
+            lastLetterWidth = [lastLetter sizeWithFont:font].width;
+        } else {
+            charSize = [letter sizeWithAttributes:stringAttrs];
+            totalWidth = [[NSString stringWithFormat:@"%@%@",lastLetter, letter] sizeWithAttributes:stringAttrs].width;
+            currentLetterWidth = [letter sizeWithAttributes:stringAttrs].width;
+            lastLetterWidth = [lastLetter sizeWithAttributes:stringAttrs].width;
+        }
+
+ 
         float kerning = (lastLetterWidth) ? 0.0 : ((currentLetterWidth + lastLetterWidth) - totalWidth);
         
         letterPosition += (charSize.width / 2) - kerning;


### PR DESCRIPTION
improve iOS 6 compatibility caused by `sizeWithAttributes:` which only
available on iOS 7.
