### PR TITLE
Add <UIKit/UIKit.h> import

### DIFF
--- a/WMGaugeView/WMGaugeViewStyle.h
+++ b/WMGaugeView/WMGaugeViewStyle.h
@@ -6,6 +6,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 /* Degrees to radians conversion macro */
 #define DEGREES_TO_RADIANS(degrees) (degrees) / 180.0 * M_PI


### PR DESCRIPTION
Add <UIKit/UIKit.h> import to allow for successful compile when project doesn't have PCH file. If not, we get compile errors with WMGaugeStyle.h, WMGaugeViewStyleFlatThin.m